### PR TITLE
Use lodash's default() function

### DIFF
--- a/src/modules/config.coffee
+++ b/src/modules/config.coffee
@@ -44,10 +44,7 @@ module.exports = (cb) ->
         # Make the request.
         request.config (err, result) ->
             # We do not strictly require config files.
-            config = {} if err or not _.isObject result
-            
-            # Tack on defaults?
-            ( config[k] ?= v for k, v of defaults )
+            config = _.defaults result, defaults
             
             # RegExpify the size label?
             if config.size_label


### PR DESCRIPTION
lodash provides a default function for this use-case. The previous code crashed with `Cannot read property of null` in line 50 when result was an object since config was still `null`.
