### PR TITLE
Add support for x-forwarded-host header

### DIFF
--- a/proxy.coffee
+++ b/proxy.coffee
@@ -20,7 +20,8 @@ proxy = (req, res, next) ->
     # Config?
     if req.url is '/config.json'
         # Refer to us like so.
-        scrubbed.host = req.headers.host
+        # Prefer custom header x-forwarded-host if defined.
+        scrubbed.host = req.headers['x-forwarded-host'] or req.headers.host
         return write 200, JSON.stringify scrubbed, null, 4
 
     # API request?


### PR DESCRIPTION
If the proxy is behind a proxy itself (like apache or nginx) `req.headers.host` points to `localhost`. This change prefers the [custom header `x-forwarded-host`](http://stackoverflow.com/questions/17085516/which-headers-should-a-proxy-send-x-forwarded-host-vs-x-host) over `req.headers.host` if it is defined.

This is especially important if the proxy runs on shared hosting where you usually can't just bind anything to a port.
