### PR TITLE
Queries and routes for Projects via GraphQL

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -22,6 +22,10 @@ let routes = {
   '/new/project': 'addProject',
   '/:owner/:name': 'milestones',
   '/:owner/:name/:milestone': 'chart',
+  '/:owner/:name/projects': 'githubProjects',
+  '/:owner/projects': 'orgProjects',
+  '/:owner/project/:project': 'orgProjectChart',
+  '/:owner/:name/project/:project': 'projectChart',
   '/demo': 'demo'
 };
 
@@ -95,11 +99,25 @@ export default React.createClass({
     return <MilestonesPage owner={owner} name={name} />;
   },
 
+  // Show projects (i.e. boards) for a repo.
+  projects(owner, name) {
+    document.title = `${owner}/${name} projects`;
+    process.nextTick(() => actions.emit('projects.load', { owner, name }));
+    return <GitHubProjectsPage owner={owner} name={name} />;
+  },
+
   // Show a project milestone chart.
   chart(owner, name, milestone) {
     document.title = `${owner}/${name}/${milestone}`;
     process.nextTick(() => actions.emit('projects.load', { owner, name, milestone }));
     return <ChartPage owner={owner} name={name} milestone={milestone} />;
+  },
+
+  // Show a GitHub project (i.e. board) chart.
+  projectChart(owner, name, project) {
+    document.title = `${owner}/${name}/${project}`;
+    process.nextTick(() => actions.emit('projects.load', { owner, name, milestone }));
+    return <ProjectChartPage owner={owner} name={name} project={project} />;
   },
 
   // Add a project.

--- a/src/js/modules/github/graphql.js
+++ b/src/js/modules/github/graphql.js
@@ -44,6 +44,11 @@ export default {
                       title
                       createdAt
                       state
+                      labels(first: 10) {
+                        nodes {
+                          name
+                        }
+                      }
                     }
                   }
                 }

--- a/src/js/modules/github/graphql.js
+++ b/src/js/modules/github/graphql.js
@@ -1,0 +1,84 @@
+// GitHub GraphQL API queries.
+
+export default {
+  allProjectsForOrg: `
+    query($login: String!) {
+      organization(login: $login) {
+        projects(first: 100) {
+          nodes {
+            name
+            number
+            createdAt
+          }
+        }
+      }
+    }
+  `,
+  allProjectsForRepo: `
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name){
+        projects(first: 100, states: OPEN) {
+          nodes {
+            name
+            number
+            createdAt
+          }
+        }
+      }
+    }
+  `,
+  oneProject: `
+    query($owner: String!, $name: String!, $project_number: Int!) {
+      repository(owner: $owner, name: $name) {
+        project(number: $project_number) {
+          createdAt
+          closedAt
+          columns(first: 10) {
+            nodes {
+              name
+              cards(first: 100) {
+                nodes {
+                  content {
+                    ... on Issue {
+                      number
+                      title
+                      createdAt
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  oneOrgProject: `
+    query($login: String!, $project_number: Int!) {
+      organization(login: $login) {
+        project(number: $project_number) {
+          createdAt
+          closedAt
+          columns(first: 10) {
+            nodes {
+              name
+              cards(first: 100) {
+                nodes {
+                  content {
+                    ... on Issue {
+                      number
+                      title
+                      createdAt
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+};

--- a/src/js/stores/projectsStore.js
+++ b/src/js/stores/projectsStore.js
@@ -76,6 +76,8 @@ class ProjectsStore extends Store {
             'owner': args.owner,
             'name': args.name
           }, args.milestone, true); // notify as well
+        } else if ('project' in args) {
+          // ...
         } else {
           // For a single project.
           _.find(this.get('list'), (obj) => {


### PR DESCRIPTION
Hi @radekstepan, here's the work you requested in https://github.com/radekstepan/burnchart/issues/129#issuecomment-395876476.

A couple things to note:
- I've implemented this using GitHub's new GraphQL API.
- The GraphQL API requires you to be logged in, even for queries on open source projects. You'll get unauthorized errors on projects until you log in.
- Projects can contain either cards or issues, so you'll want to filter down to just the issues.
- I haven't implemented any sort of pagination.
- Projects due not have due dates like Milestones do.
- There are two types of projects, org-level and repo-level. Org-level projects can contain issues from any repo in the organization. This means that burnchart's current approach of fetching all issues in a repo and then linking issue IDs to a milestone won't work. Fortunately GraphQL lets us do everything in a single query.
- I've left some logging / debugging code in.

I added routes but they're more of a suggestion. I've verified that one of the queries in `requests.js` worked in the browser and verified all the GraphQL queries in the GraphQL API Explorer.

Let me know if this is enough for you to take over.